### PR TITLE
Convert HashPath to a global template function

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -3,7 +3,3 @@
 if (file_exists(__DIR__ . '../vendor/autoload.php')) {
     require_once __DIR__ . '../vendor/autoload.php';
 }
-
-if (class_exists('ContentController')) {
-    Object::add_extension('ContentController', 'HashPathExtension');
-}

--- a/code/HashPath.php
+++ b/code/HashPath.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Class HashPath
+ */
+class HashPath implements TemplateGlobalProvider
+{
+    /**
+     * The format of the web path
+     * @var string
+     */
+    protected static $format = '%s/%s.v%s.%s';
+    /**
+     * Whether or not to output links as relative
+     * @var boolean
+     */
+    protected static $relativeLinks = false;
+    /**
+     * Set the format for use in producing the web path
+     * @param string $format The format to set
+     */
+    public static function setFormat($format)
+    {
+        self::$format = $format;
+    }
+    /**
+     * Output links as relative
+     * @param boolean $val Whether or not to output links as relative
+     */
+    public static function setRelativeLinks($val = true)
+    {
+        self::$relativeLinks = $val;
+    }
+    /**
+     * Returns an md5 hash of a file
+     * @param  string  $path  Relative or absolute path to file
+     * @param  boolean $theme Whether or not to take current theme into account
+     * @return string  The md5 of the file
+     */
+    public static function generateHashForFile($path, $theme = true)
+    {
+        $path = $theme ? static::getPath($path) : $path;
+
+        if (file_exists($path)) {
+            $hash = md5_file($path);
+            return str_replace(array('/', '+','='), '', base64_encode(pack('H*', $hash)));
+        }
+
+        return '';
+    }
+    /**
+     * Template function to return new web path to asset which includes
+     * md5 hash
+     * @param  string  $path  Relative or absolute path to file
+     * @param  boolean $theme Whether or not to take current theme into account
+     * @return string  The web path include the md5 hash
+     */
+    public static function generateHashForPath($path, $theme = true)
+    {
+        $filepath = static::getPath($path, $theme);
+        $path_parts = pathinfo($filepath);
+
+        return sprintf(
+            self::$format,
+            str_replace(BASE_PATH . (self::$relativeLinks ? '/' : ''), '', $path_parts['dirname']),
+            basename($path, ".{$path_parts['extension']}"),
+            static::generateHashForFile($filepath, false),
+            $path_parts['extension']
+        );
+    }
+    /**
+     * Returns the absolute path to a file based on whether or not
+     * the input is relative to the current theme
+     * @param  string  $path  Relative or absolute path to file
+     * @param  boolean $theme Whether or not to take current theme into account
+     * @return string  The absolute path to the file
+     */
+    protected static function getPath($path, $theme = true)
+    {
+        return BASE_PATH . (
+            $theme ? '/themes/' . Config::inst()->get('SSViewer', 'theme') . "/$path" : $path
+        );
+    }
+
+    public static function get_template_global_variables()
+    {
+        return array(
+            'HashFile' => 'generateHashForFile',
+            'HashPath' => 'generateHashForPath'
+        );
+    }
+}

--- a/code/HashPathExtension.php
+++ b/code/HashPathExtension.php
@@ -2,84 +2,31 @@
 
 /**
  * Class HashPathExtension
+ * @deprecated 
  */
-class HashPathExtension extends Extension
+class HashPathExtension
 {
-    /**
-     * The format of the web path
-     * @var string
-     */
-    protected static $format = '%s/%s.v%s.%s';
-    /**
-     * Whether or not to output links as relative
-     * @var boolean
-     */
-    protected static $relativeLinks = false;
-    /**
-     * Set the format for use in producing the web path
-     * @param string $format The format to set
-     */
-    public static function setFormat($format)
+    public static function setFormat($format) 
     {
-        self::$format = $format;
-    }
-    /**
-     * Output links as relative
-     * @param boolean $val Whether or not to output links as relative
-     */
-    public static function setRelativeLinks($val = true)
-    {
-        self::$relativeLinks = $val;
-    }
-    /**
-     * Returns an md5 hash of a file
-     * @param  string  $path  Relative or absolute path to file
-     * @param  boolean $theme Whether or not to take current theme into account
-     * @return string  The md5 of the file
-     */
-    public function HashFile($path, $theme = true)
-    {
-        $path = $theme ? $this->getPath($path) : $path;
-
-        if (file_exists($path)) {
-            $hash = md5_file($path);
-            return str_replace(array('/', '+','='), '', base64_encode(pack('H*', $hash)));
-        }
-        
-        return '';
-    }
-    /**
-     * Template function to return new web path to asset which includes
-     * md5 hash
-     * @param  string  $path  Relative or absolute path to file
-     * @param  boolean $theme Whether or not to take current theme into account
-     * @return string  The web path include the md5 hash
-     */
-    public function HashPath($path, $theme = true)
-    {
-        $filepath = $this->getPath($path, $theme);
-        $path_parts = pathinfo($filepath);
-
-        return sprintf(
-            self::$format,
-            str_replace(BASE_PATH . (self::$relativeLinks ? '/' : ''), '', $path_parts['dirname']),
-            basename($path, ".{$path_parts['extension']}"),
-            $this->HashFile($filepath, false),
-            $path_parts['extension']
-        );
-    }
-    /**
-     * Returns the absolute path to a file based on whether or not
-     * the input is relative to the current theme
-     * @param  string  $path  Relative or absolute path to file
-     * @param  boolean $theme Whether or not to take current theme into account
-     * @return string  The absolute path to the file
-     */
-    protected function getPath($path, $theme = true)
-    {
-        return BASE_PATH . (
-            $theme ? '/themes/' . Config::inst()->get('SSViewer', 'theme') . "/$path" : $path
-        );
+        Deprecation::notice('1.0', 'Use HashPath::setFormat instead');
+        HashPath::setFormat($format);
     }
 
+    public static function setRelativeLinks($val = true) 
+    {
+        Deprecation::notice('1.0', 'Use HashPath::setRelativeLinks instead');
+        HashPath::setRelativeLinks($val);
+    }
+
+    public function HashFile($path, $theme = true) 
+    {
+        Deprecation::notice('1.0', 'Use HashPath::generateHashForFile instead');
+        return HashPath::generateHashForFile($path, $theme);
+    }
+
+    public function HashPath($path, $theme = true) 
+    {
+        Deprecation::notice('1.0', 'Use HashPath::generateHashForPath instead');
+        return HashPath::generateHashForPath($path, $theme);
+    }
 }

--- a/tests/HashPathExtensionTest.php
+++ b/tests/HashPathExtensionTest.php
@@ -2,15 +2,11 @@
 
 class HashPathExtensionTest extends PHPUnit_Framework_TestCase
 {
-
     public function testHashFile()
     {
-
-        $hashPath = new HashPathExtension();
-
         $this->assertEquals(
             'L32cPgz9Rj8qwwSRHsr8A',
-            $hashPath->HashFile(
+            HashPath::generateHashForFile(
                 __DIR__ . '/test.txt',
                 false
             )
@@ -18,37 +14,38 @@ class HashPathExtensionTest extends PHPUnit_Framework_TestCase
         
         $this->assertEquals(
             '',
-            $hashPath->HashFile(
+            HashPath::generateHashForFile(
                 'fakefile',
                 false
             )
         );
-
     }
 
     public function testHashPath()
     {
-
-        $hashPath = new HashPathExtension();
-
         $this->assertEquals(
             '/tests/test.vL32cPgz9Rj8qwwSRHsr8A.txt',
-            $hashPath->HashPath(
+            HashPath::generateHashForPath(
                 '/tests/test.txt',
                 false
             )
         );
 
-        $hashPath->setFormat('%s/%s.v.%s.%s');
+        HashPath::setFormat('%s/%s.v.%s.%s');
 
         $this->assertEquals(
             '/tests/test.v.L32cPgz9Rj8qwwSRHsr8A.txt',
-            $hashPath->HashPath(
+            HashPath::generateHashForPath(
                 '/tests/test.txt',
                 false
             )
         );
-
     }
-
+    
+    public function testGlobalTemplateConfiguration()
+    {
+        $globalTemplateVars = HashPath::get_template_global_variables();
+        $this->assertEquals('generateHashForFile', $globalTemplateVars['HashFile']);
+        $this->assertEquals('generateHashForPath', $globalTemplateVars['HashPath']);
+    }
 }


### PR DESCRIPTION
This allows it to be used on templates rendered not using the CMS (eg, static controllers and direct `SS_Viewer` access).

Due to the nature of the refactor, this should be a non-breaking change.
