### PR TITLE
Update Code for Silverstripe 4

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -5,5 +5,5 @@ if (file_exists(__DIR__ . '../vendor/autoload.php')) {
 }
 
 if (class_exists('SilverStripe\CMS\Controllers\ContentController')) {
-    \SilverStripe\Core\Extensible::add_extension('SilverStripe\CMS\Controllers\ContentController', 'Heyday\HashPath\HashPathExtension');
+    \SilverStripe\CMS\Controllers\ContentController::add_extension('SilverStripe\CMS\Controllers\ContentController', 'Heyday\HashPath\HashPathExtension');
 }


### PR DESCRIPTION
In Silverstripe 4 Object Classes are replaced by traits. Update the code to comply.

https://docs.silverstripe.org/en/4/changelogs/4.0.0/#object-replace